### PR TITLE
tmp: test env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,6 @@ on:
 jobs:
   test:
     uses: dominykas/pkgjs-action/.github/workflows/node-test.yaml@main
-    with:
-      env-test: |
+    secrets:
+      env-test: |-
         {"TESTING_TESTING":"x"}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,4 +8,5 @@ jobs:
   test:
     uses: dominykas/pkgjs-action/.github/workflows/node-test.yaml@main
     with:
-      test-command: false
+      env-test: |
+        {"TESTING_TESTING":"x"}

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -46,6 +46,12 @@ on:
         required: false
         type: string
 
+      env-test:
+        description: "testing."
+        default: "{}"
+        required: false
+        type: string
+
 jobs:
 
   prepare-node-matrix:
@@ -127,11 +133,17 @@ jobs:
       uses: ./.github/tmp/post-install-steps
 
 
+    - name: Set environment variables
+      id: set-test-env
+      run: |
+        MATRIX_VARS='{"MATRIX_NODE_VERSION":"${{ matrix.node-version }}","NODE_LTS_LATEST":"${{ needs.prepare-node-matrix.outputs.lts-latest }}"}'
+        INPUT_VARS='${{ inputs.env-test }}'
+        MERGED_VARS=$(echo ${INPUT_VARS} ${MATRIX_VARS} | jq -c -s '.[0] * .[1]')
+        echo "::set-output name=test-env::${MERGED_VARS}"
+
     - name: Run tests
       run: ${{ inputs.test-command }}
-      env:
-        MATRIX_NODE_VERSION: ${{ matrix.node-version }}
-        NODE_LTS_LATEST: ${{ needs.prepare-node-matrix.outputs.lts-latest }}
+      env: ${{ fromJson(steps.set-test-env.outputs.test-env) }}
 
     - name: Run post-test steps
       if: ${{ inputs.post-test-steps }}

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -46,11 +46,10 @@ on:
         required: false
         type: string
 
+    secrets:
       env-test:
         description: "testing."
-        default: "{}"
         required: false
-        type: string
 
 jobs:
 
@@ -137,7 +136,7 @@ jobs:
       id: set-test-env
       run: |
         MATRIX_VARS='{"MATRIX_NODE_VERSION":"${{ matrix.node-version }}","NODE_LTS_LATEST":"${{ needs.prepare-node-matrix.outputs.lts-latest }}"}'
-        INPUT_VARS='${{ inputs.env-test }}'
+        INPUT_VARS='${{ secrets.env-test }}'
         MERGED_VARS=$(echo ${INPUT_VARS} ${MATRIX_VARS} | jq -c -s '.[0] * .[1]')
         echo "::set-output name=test-env::${MERGED_VARS}"
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Github Actions tooling for testing Node.js packages",
   "scripts": {
     "lint": "[ \"$NODE_LTS_LATEST\" != \"\" ] && [ \"$MATRIX_NODE_VERSION\" != \"$NODE_LTS_LATEST\" ] && echo 'Skipping linting' || npx -- eslint .github",
-    "test": "for PRIVATE_ACTION in .github/actions/*/; do cd ${INIT_CWD}/${PRIVATE_ACTION} && npm test || exit 1; done && cd ${INIT_CWD} && npm run lint"
+    "test": "echo tt: ${TESTING_TESTING}"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Keeping a record of an attempt to pass env vars.

Bad idea, because env vars get printed in the output for the action (see screenshot) - the secret is only the full stringified JSON.

![Screen Shot 2022-01-02 at 13 29 46](https://user-images.githubusercontent.com/505619/147874358-edbdef74-45a6-4f30-946e-a5c9a790d11a.png)